### PR TITLE
Update ContentTV.php

### DIFF
--- a/src/Traits/ContentTV.php
+++ b/src/Traits/ContentTV.php
@@ -117,7 +117,7 @@ trait ContentTV
             $display = APIhelpers::getkey($param, 'display', '');
             $display_params = APIhelpers::getkey($param, 'display_params', '');
             $type = APIhelpers::getkey($param, 'type', '');
-            $out = getTVDisplayFormat($tvname, $tvval, $display, $display_params, $type, $this->getID(), '');
+            $out = getTVDisplayFormat($tvname, $tvval ?? '', $display, $display_params, $type, $this->getID(), '');
         }
 
         return $out;


### PR DESCRIPTION
Значение tvval  может приехать и из APIhelpers::getkey(), которое может в том числе вернуть и null. Соответствено падает вызов функции (которая  к слову сказать продублирована в двух файлах), но и там и там требуется string в качестве значения.